### PR TITLE
feat: 添加全局贴表情开关

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 class Config {
     static config = {
+        autoStick: false, // 自动贴表情开关
         stickSelfAmount: 1,//给自己贴表情的个数
         stickOtherAmount:5,//给其他人贴表情的个数
         useCarousel:false,

--- a/src/pluginMenu.html
+++ b/src/pluginMenu.html
@@ -5,6 +5,15 @@
             <setting-list data-direction="column">
                 <setting-item data-direction="row">
                     <div>
+                        <setting-text>自动贴表情开关</setting-text>
+                        <setting-text data-type="secondary">只有开启后，才会在消息后自动贴表情；否则，需要手动在右键菜单中选择。
+                        </setting-text>
+                    </div>
+                    <setting-switch id="auto-stick-switch" style="cursor: pointer"></setting-switch>
+                </setting-item>
+
+                <setting-item data-direction="row">
+                    <div>
                         <setting-text>贴自我消息表情</setting-text>
                         <setting-text data-type="secondary">开启后，自己的每条消息发送后都会贴上指定数量的表情。
                         </setting-text>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -55,6 +55,12 @@ async function onHashUpdate() {
         const listener1 = pluginAPI.subscribeEvent('nodeIKernelMsgListener/onMsgInfoListUpdate',
             async (payload) => {
                 console.log(payload)
+                // 先检查配置中的自动贴表情开关
+                const config = await pluginAPI.getConfig()
+                if (!config.autoStick) {
+                    pluginLog("自动贴表情功能未开启")
+                    return
+                }
                 await retry(() => stickEmojiSelf(payload), 10, 150)
             })
         listenMenu()

--- a/src/utils/SettingListeners.js
+++ b/src/utils/SettingListeners.js
@@ -7,6 +7,18 @@ export class SettingListeners {
         this.document = doc
     }
 
+    async autoStickSwitchListener() {
+        const mySwitch = this.document.querySelector('#auto-stick-switch')
+        if ((await pluginAPI.getConfig()).autoStick) mySwitch.toggleAttribute('is-active')
+
+        mySwitch.addEventListener('click', async () => {
+            const autoStick = (await pluginAPI.getConfig()).autoStick
+            mySwitch.toggleAttribute('is-active')
+            // 修改状态
+            await pluginAPI.setConfig({autoStick: !autoStick})
+        })
+    }
+
     //贴自己表情
     async stickSelfRangeListener() {
         const range = this.document.querySelector('#stick-self-range')
@@ -99,6 +111,7 @@ export class SettingListeners {
     }
 
     onLoad() {
+        this.autoStickSwitchListener()
         this.stickSelfRangeListener()
         this.stickOtherRangeListener()
         this.repoButtonListener()


### PR DESCRIPTION
之前没有一个全局开关来开启关闭贴表情，只能通过调整个数来使用，导致每次要去设置里调。

修改后，添加了一个全局开关用于调整该选项，这下想手动贴的时候也能贴的出来了。

feat: Implement auto-stick emoji feature with configuration toggle

- Added 'autoStick' configuration option to enable/disable automatic emoji sticking.
- Updated plugin menu to include a switch for the auto-stick feature with explanatory text.
- Integrated auto-stick functionality into message handling logic, checking the configuration before applying emojis.
- Implemented event listener for the auto-stick switch to update the configuration dynamically.